### PR TITLE
Add new DAO site

### DIFF
--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        site: [landing, tv]
+        site: [dao, landing, tv]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v1

--- a/sites/.common/site/layouts/partials/footer.html
+++ b/sites/.common/site/layouts/partials/footer.html
@@ -1,0 +1,3 @@
+<footer class="has-background-charcoal has-text-white has-text-weight-semibold has-text-centered">
+    <span>Made with 🔥by humans</span>
+</footer>

--- a/sites/.common/site/layouts/partials/header.html
+++ b/sites/.common/site/layouts/partials/header.html
@@ -1,0 +1,9 @@
+<nav class="navbar is-fixed-top" role="navigation" aria-label="main navigation">
+  <div class="container">
+    <div class="navbar-brand">
+      <a class="navbar-item is-size-3 is-size-4-touch" href="https://bonfire.link">
+        bonfire.link
+      </a>
+    </div>
+  </div>
+</nav>

--- a/sites/.common/src/common.js
+++ b/sites/.common/src/common.js
@@ -1,0 +1,8 @@
+// source: http://youmightnotneedjquery.com/#ready
+export function ready(fn) {
+  if (document.readyState != 'loading') {
+    fn();
+  } else {
+    document.addEventListener('DOMContentLoaded', fn);
+  }
+}

--- a/sites/.common/src/scss/common.scss
+++ b/sites/.common/src/scss/common.scss
@@ -12,6 +12,11 @@ $navbar-item-color: white;
 $navbar-item-hover-color: $fire;
 $navbar-item-hover-background-color: 'transparent';
 
+// progress customizations
+.progress.is-smallest {
+  height: 0.25rem;
+}
+
 // typography customizations
 @font-face {
   font-family: 'Do Hyeon';

--- a/sites/.common/src/scss/common.scss
+++ b/sites/.common/src/scss/common.scss
@@ -4,6 +4,7 @@ $charcoal: #2e2e3a;
 $text: $charcoal;
 $link: $charcoal;
 $link-hover: $fire;
+$danger: $fire;
 
 // navbar customizations
 $navbar-background-color: $charcoal;

--- a/sites/.common/src/scss/common.scss
+++ b/sites/.common/src/scss/common.scss
@@ -54,6 +54,10 @@ a {
   background: $charcoal;
 }
 
+.is-vcentered {
+  align-items: center;
+}
+
 .navbar-brand {
   align-items: center;
 
@@ -77,9 +81,4 @@ footer {
 
 .hero.is-fullheight.is-not-fullheight {
   min-height: 95vh;
-}
-
-.container.has-flex-align-items-center {
-  display: flex;
-  align-items: center;
 }

--- a/sites/dao/.babelrc
+++ b/sites/dao/.babelrc
@@ -1,0 +1,1 @@
+../.common/.babelrc

--- a/sites/dao/.eslintrc.yml
+++ b/sites/dao/.eslintrc.yml
@@ -1,0 +1,1 @@
+../.common/.eslintrc.yml

--- a/sites/dao/.nvmrc
+++ b/sites/dao/.nvmrc
@@ -1,0 +1,1 @@
+../.common/.nvmrc

--- a/sites/dao/README.md
+++ b/sites/dao/README.md
@@ -1,0 +1,1 @@
+../.common/README.md

--- a/sites/dao/netlify.toml
+++ b/sites/dao/netlify.toml
@@ -1,0 +1,1 @@
+../.common/netlify.toml

--- a/sites/dao/package-lock.json
+++ b/sites/dao/package-lock.json
@@ -1,0 +1,1 @@
+../.common/package-lock.json

--- a/sites/dao/package.json
+++ b/sites/dao/package.json
@@ -1,0 +1,1 @@
+../.common/package.json

--- a/sites/dao/postcss.config.js
+++ b/sites/dao/postcss.config.js
@@ -1,0 +1,1 @@
+../.common/postcss.config.js

--- a/sites/dao/renovate.json
+++ b/sites/dao/renovate.json
@@ -1,0 +1,1 @@
+../.common/renovate.json

--- a/sites/dao/site/config.toml
+++ b/sites/dao/site/config.toml
@@ -1,0 +1,9 @@
+baseurl = "/"
+languageCode = "en-us"
+languageLang = "en"
+title = "bonfire.link - not a dao"
+
+# RSS, categories and tags disabled for an easy start
+# See configuration options for more details:
+# https://gohugo.io/getting-started/configuration/#toml-configuration
+disableKinds = ["RSS", "taxonomy", "taxonomyTerm"]

--- a/sites/dao/site/layouts/404.html
+++ b/sites/dao/site/layouts/404.html
@@ -1,0 +1,1 @@
+../../../.common/site/layouts/404.html

--- a/sites/dao/site/layouts/_default/baseof.html
+++ b/sites/dao/site/layouts/_default/baseof.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html lang="{{ $.Site.Language.Lang }}">
+
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+  <base href="{{ if getenv "CONTEXT" }}{{ cond (eq "production" (getenv "CONTEXT")) (getenv "URL") (getenv "DEPLOY_PRIME_URL") }}{{ else }}{{ $.Site.BaseURL }}{{ end }}">
+  <title>{{ $.Site.Title }}</title>
+
+  {{ $stylesheet := .Site.Data.webpack.main }}
+  {{ with $stylesheet.css }}
+    <link href="{{ relURL . }}" rel="stylesheet">
+  {{ end }}
+</head>
+
+<body>
+
+  {{ block "header" . }}{{ partial "header" . }}{{end}}
+
+  {{ block "main" . }}{{end}}
+
+  {{ if not .IsHome }}
+    <!-- Footer in home page is directly added inside the hero -->
+    {{ block "footer" . }}{{ partial "footer" . }}{{end}}
+  {{ end }}
+
+  {{ $script := .Site.Data.webpack.main }}
+  {{ with $script.js }}
+    <script src="{{ relURL . }}"></script>
+  {{ end }}
+</body>
+
+</html>

--- a/sites/dao/site/layouts/index.html
+++ b/sites/dao/site/layouts/index.html
@@ -1,0 +1,36 @@
+{{ define "main" }}
+<section class="hero has-columns is-fullheight">
+  <div class="hero-body has-background-fire">
+    <div class="container is-size-5 is-italic">
+      <div class="columns is-variable is-6 is-vcentered is-centered has-text-centered has-text-white">
+        <div class="column is-3">
+          on the 6th month of the year<br/>
+          on the 6th day of that month<br/>
+          on the 6th night of the week<br/>
+          at the cold hands of machines<br/>
+          gods of paper came to die.
+        </div>
+        <div class="column is-4">
+          shadows dreamt of endless fire<br/>
+          amidst smoke and broken light<br/>
+          idols chained into existence<br/>
+          now awaiting sacrifice.
+        </div>
+        <div class="column is-3">
+          fearful soul, be so no longer<br/>
+          as in darkness you shall thrive<br/>
+          and rejoice in such a pleasure<br/>
+          that it is to keep your secrets<br/>
+          and in ether sin ablaze.
+        </div>
+      </div>
+      <div class="progress-container is-flex">
+        <progress id="progress" class="progress is-smallest is-danger" value="0"></progress>
+      </div>
+    </div>
+  </div>
+  <div class="hero-footer">
+    {{ block "footer" . }}{{ partial "footer" . }}{{end}}
+  </div>
+</section>
+{{ end }}

--- a/sites/dao/site/layouts/partials/footer.html
+++ b/sites/dao/site/layouts/partials/footer.html
@@ -1,0 +1,3 @@
+<footer class="has-background-charcoal has-text-white has-text-weight-semibold has-text-centered">
+    <span>Made with 🔥by humans</span>
+</footer>

--- a/sites/dao/site/layouts/partials/footer.html
+++ b/sites/dao/site/layouts/partials/footer.html
@@ -1,3 +1,1 @@
-<footer class="has-background-charcoal has-text-white has-text-weight-semibold has-text-centered">
-    <span>Made with 🔥by humans</span>
-</footer>
+../../../../.common/site/layouts/partials/footer.html

--- a/sites/dao/site/layouts/partials/header.html
+++ b/sites/dao/site/layouts/partials/header.html
@@ -1,9 +1,1 @@
-<nav class="navbar is-fixed-top" role="navigation" aria-label="main navigation">
-  <div class="container">
-    <div class="navbar-brand">
-      <a class="navbar-item is-size-3 is-size-4-touch" href="https://bonfire.link">
-        bonfire.link
-      </a>
-    </div>
-  </div>
-</nav>
+../../../../.common/site/layouts/partials/header.html

--- a/sites/dao/site/layouts/partials/header.html
+++ b/sites/dao/site/layouts/partials/header.html
@@ -1,0 +1,9 @@
+<nav class="navbar is-fixed-top" role="navigation" aria-label="main navigation">
+  <div class="container">
+    <div class="navbar-brand">
+      <a class="navbar-item is-size-3 is-size-4-touch" href="https://bonfire.link">
+        bonfire.link
+      </a>
+    </div>
+  </div>
+</nav>

--- a/sites/dao/site/static/pipe.png
+++ b/sites/dao/site/static/pipe.png
@@ -1,0 +1,1 @@
+../../../.common/site/static/pipe.png

--- a/sites/dao/src/common.js
+++ b/sites/dao/src/common.js
@@ -1,0 +1,1 @@
+../../.common/src/common.js

--- a/sites/dao/src/fonts
+++ b/sites/dao/src/fonts
@@ -1,0 +1,1 @@
+../../.common/src/fonts

--- a/sites/dao/src/index.js
+++ b/sites/dao/src/index.js
@@ -1,0 +1,14 @@
+// JS Goes here - ES6 supported
+
+import "./scss/main.scss";
+import * as common from "./common.js";
+
+function redirectToAragon() {
+  const progress = document.getElementById("progress");
+  progress.style.transition = 'width 10s linear';
+  progress.style.width = '0%';
+  // TODO: add debug flag to disable redirection
+  setTimeout((() => window.location.href = 'https://mainnet.aragon.org/#/notadao'), 10000);
+}
+
+common.ready(redirectToAragon);

--- a/sites/dao/src/scss/common.scss
+++ b/sites/dao/src/scss/common.scss
@@ -1,0 +1,1 @@
+../../../.common/src/scss/common.scss

--- a/sites/dao/src/scss/main.scss
+++ b/sites/dao/src/scss/main.scss
@@ -1,0 +1,11 @@
+@import "common.scss";
+@import "~bulma/bulma";
+
+.hero.has-columns .columns {
+  margin: 2rem;
+}
+
+.progress-container {
+  justify-content: space-evenly;
+  margin: 5rem 5rem 0;
+}

--- a/sites/dao/webpack.common.js
+++ b/sites/dao/webpack.common.js
@@ -1,0 +1,1 @@
+../.common/webpack.common.js

--- a/sites/dao/webpack.dev.js
+++ b/sites/dao/webpack.dev.js
@@ -1,0 +1,1 @@
+../.common/webpack.dev.js

--- a/sites/dao/webpack.prod.js
+++ b/sites/dao/webpack.prod.js
@@ -1,0 +1,1 @@
+../.common/webpack.prod.js

--- a/sites/landing/site/layouts/index.html
+++ b/sites/landing/site/layouts/index.html
@@ -57,7 +57,7 @@
 </section>
 
 <section class="hero has-columns is-fullheight is-not-fullheight has-background-fire has-text-white">
-  <div class="container has-flex-align-items-center">
+  <div class="container is-flex is-vcentered">
     <div class="columns is-variable is-8">
       <div class="column">
         <h2 class="is-size-3 is-size-4-touch">survive.</h2>

--- a/sites/landing/site/layouts/partials/footer.html
+++ b/sites/landing/site/layouts/partials/footer.html
@@ -1,3 +1,1 @@
-<footer class="has-background-charcoal has-text-white has-text-weight-semibold has-text-centered">
-    <span>Made with 🔥by humans</span>
-</footer>
+../../../../.common/site/layouts/partials/footer.html

--- a/sites/landing/site/layouts/partials/header.html
+++ b/sites/landing/site/layouts/partials/header.html
@@ -1,9 +1,1 @@
-<nav class="navbar is-fixed-top" role="navigation" aria-label="main navigation">
-  <div class="container">
-    <div class="navbar-brand">
-      <a class="navbar-item is-size-3 is-size-4-touch" href="https://bonfire.link">
-        bonfire.link
-      </a>
-    </div>
-  </div>
-</nav>
+../../../../.common/site/layouts/partials/header.html

--- a/sites/tv/site/layouts/partials/footer.html
+++ b/sites/tv/site/layouts/partials/footer.html
@@ -1,3 +1,1 @@
-<footer class="has-background-charcoal has-text-white has-text-weight-semibold has-text-centered">
-    <span>Made with 🔥by humans</span>
-</footer>
+../../../../.common/site/layouts/partials/footer.html

--- a/sites/tv/site/layouts/partials/header.html
+++ b/sites/tv/site/layouts/partials/header.html
@@ -1,9 +1,1 @@
-<nav class="navbar is-fixed-top" role="navigation" aria-label="main navigation">
-  <div class="container">
-    <div class="navbar-brand">
-      <a class="navbar-item is-size-3 is-size-4-touch" href="https://bonfire.link">
-        bonfire.link
-      </a>
-    </div>
-  </div>
-</nav>
+../../../../.common/site/layouts/partials/header.html


### PR DESCRIPTION
This site displays the little deployment poem we wrote and redirects to the [Aragon DAO in mainnet](https://mainnet.aragon.org/#/notadao) after 10 seconds. The idea would be to serve this on https://notadao.bonfire.link and add a link to it in all site headers.

![image](https://user-images.githubusercontent.com/716307/84606266-d636b300-aea4-11ea-94c6-4ef3f52cd803.png)

_Note: it doesn't look nice on mobile._